### PR TITLE
Update .gitignore to exclude reference_repo_5-11-25

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ Thumbs.db
 reference_repo/
 
 clone_of_working_profiling_app2/
+
+# Local reference repo (exclude from git)
+reference_repo_5-11-25/


### PR DESCRIPTION
1. UI fixes. Alignment for Profile Image at 100%, 90% and 80% ZOOM, Fixed Account dropdown highlighted option
2. Update .gitignore to exclude reference_repo_5-11-25